### PR TITLE
Compliance with package.el format

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -1,11 +1,12 @@
 ;;; evil-org-mode.el --- evil keybindings for org-mode
 
-;; Copyright: See respective authors
-;; Author: See respective commits
+;; Copyright (C) 2012-2013 by Edward Tjörnhammar
+;; Author: Edward Tjörnhammar
 ;; URL: https://github.com/edwtjo/evil-org-mode.git
 ;; Git-Repository; git://github.com/edwtjo/evil-org-mode.git
 ;; Created: 2012-06-14
-;; Version: 9999
+;; Version: 0.1.0
+;; Package-Requires: ((evil "0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
 ;; This file is not part of GNU Emacs
@@ -27,7 +28,7 @@
 ;; See, https://github.com/edwtjo/evil-org-mode/issues
 
 (require 'evil)
-(require 'evil-leader)
+;; (require 'evil-leader)
 (require 'org)
 
 (define-minor-mode evil-org-mode
@@ -75,3 +76,5 @@
             (kbd "M-K") 'org-shiftmetaup
             (kbd "M-J") 'org-shiftmetadown)) '(normal insert))
 (provide 'evil-org)
+
+;;; evil-org-mode.el ends here


### PR DESCRIPTION
The purpose here is to prepare for easy distribution via
package.el (melpa, marmalade...). The format is described here:
http://marmalade-repo.org/doc-files/package.5.html

Totally arbitrarily, I decided it wasn't version 9999 anymore but 0.1.0.

I commented out the `(require 'evil-leader)` as this doesn't seem
necessary anymore.

This request being merged, this will enable the creation of a recipe in the [melpa repository](https://github.com/milkypostman/melpa)

File to create `recipes/evil-org-mode`:


``` elisp
    (evil-org-mode :repo "edwtjo/evil-org-mode" :fetcher github)
```

I have successfully tested locally with my fork of melpa and evil-org-mode witht this recipe:


``` elisp
    (evil-org-mode :repo "behaghel/evil-org-mode" :fetcher github)
```

This compiled successfully with this output:

```
~/Temp/melpa[evil-org] % make recipes/evil-org-mode 
 • Building recipe evil-org-mode ...
rm -vf ./packages/evil-org-mode-*
./packages/evil-org-mode-20120618.1413.el
emacs --no-site-file --batch -l package-build.el --eval "(package-build-archive 'evil-org-mode)"
Loading /Users/hub/Temp/melpa/json-fix.el (source)...
Recipe 'evil-org-mode~' contains mismatched package name 'evil-leader'

;;; evil-org-mode

Fetcher: github
Source: behaghel/evil-org-mode

Cloning git://github.com/behaghel/evil-org-mode.git to /Users/hub/Temp/melpa/working/evil-org-mode/
Removing archive: (evil-org-mode . [(20120618 1413) nil No description available. [source: github] single])
Loading vc-git...
Saving file /Users/hub/Temp/melpa/packages/evil-org-mode-20130505.1433.el...
Wrote /Users/hub/Temp/melpa/packages/evil-org-mode-20130505.1433.el
Wrote /Users/hub/Temp/melpa/packages/archive-contents
Built in 0.430s, finished at Sun May  5 14:39:38 2013
 ✓ Wrote 8 -rw-r--r--  1 hub  staff   2.7K May  5 14:39 ./packages/evil-org-mode-20130505.1433.el 
```

The resulting package successfully installed with this output:

```
    Compiling file /Users/hub/.emacs.d/elpa/evil-org-mode-20130505.1433/evil-org-mode-pkg.el at Sun May  5 14:57:02 2013
    Entering directory `/Users/hub/.emacs.d/elpa/evil-org-mode-20130505.1433/'
    
    Compiling file /Users/hub/.emacs.d/elpa/evil-org-mode-20130505.1433/evil-org-mode.el at Sun May  5 14:57:02 2013
    evil-org-mode.el:69:2:Warning: `mapcar' called for effect; use `mapc' or
    `dolist' instead
```

If that helps, I am happy to request a pull with the right recipe into melpa when this is merged.
