### PR TITLE
make evil leader bindings optional 

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,6 +23,14 @@ Supplemental evil-mode key-bindings to Emacs org-mode. This is a work in progres
     (require 'evil-org)
 #+end_src
 
+You can also optionally disable the evil leader key bindings from being
+activated with:
+
+#+begin_src emacs-lisp
+    (setq evil-org-set-leader nil)
+#+end_src
+
+
 * Keys
 Here are the keys introduced by evil-org
 

--- a/evil-org.el
+++ b/evil-org.el
@@ -108,12 +108,22 @@
   "-" 'org-cycle-list-bullet
   (kbd "TAB") 'org-cycle)
 
+;; allow user to unset map
+(defun unset-or-true (symbol)
+  (or (not (boundp symbol)) (symbol-value symbol)))
+
 ;; leader maps
-(evil-leader/set-key
-  "t"  'org-show-todo-tree
-  "a"  'org-agenda
-  "x"  'org-archive-subtree
-)
+(if (unset-or-true 'evil-org-set-leader)
+    (progn
+    (evil-leader/set-key
+      "t"  'org-show-todo-tree
+      "a"  'org-agenda
+      "x"  'org-archive-subtree
+      )
+    (message "bound-evil-leader")
+      )
+  'false
+  )
 
 ;; normal & insert state shortcuts.
 (mapc (lambda (state)


### PR DESCRIPTION
The evil leader bindings step on my setup so I made them optional. The default is to create the evil leader keybindings so nothing changes unless you use `(setq evil-org-set-leader nil)`
