### PR TITLE
Localize evil-leader bindings only to org-mode

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -109,7 +109,7 @@
   (kbd "TAB") 'org-cycle)
 
 ;; leader maps
-(evil-leader/set-key
+(evil-leader/set-key-for-mode 'org-mode
   "t"  'org-show-todo-tree
   "a"  'org-agenda
   "x"  'org-archive-subtree


### PR DESCRIPTION
Use `evil-leader/set-key-for-mode` instead of `evil-leader/set-key` to localize the leader bindings only when `org-mode` is enabled. Otherwise, either evil-org-mode or the user's leader bindings will clobber the other, whichever is loaded last.
