### PR TITLE
Use <tab> binding instead of TAB to allow separate binding of C-i

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -141,7 +141,7 @@ FUN function callback"
   "<" 'org-metaleft
   ">" 'org-metaright
   "-" 'org-cycle-list-bullet
-  (kbd "TAB") 'org-cycle)
+  (kbd "<tab>") 'org-cycle)
 
 ;; leader maps
 (evil-leader/set-key-for-mode 'org-mode


### PR DESCRIPTION
When using the `TAB` keycode, one can then apply different keybinding for <kbd>Ctrl</kbd> + <kbd>i</kbd> and <kbd>tab</kbd> (cf. [this emacs.sx question and answer](http://emacs.stackexchange.com/questions/9631/what-is-the-difference-between-tab-and-tab) or the [emacs lisp documentation on function keys](http://www.gnu.org/software/emacs/manual/html_node/elisp/Function-Keys.html)). 

Using the `<tab>` code does not have this problem. This pull request fixes the problem.

…. http://www.gnu.org/software/emacs/manual/html_node/elisp/Function-Keys.html