### PR TITLE
fix clever-insert-item so o respects folded headings

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -45,7 +45,7 @@
 (defun clever-insert-item ()
   "Clever insertion of org item."
   (if (not (org-in-item-p))
-      (insert "\n")
+    (evil-open-below nil)
     (org-insert-item))
   )
 


### PR DESCRIPTION
Here's my suggested fix for issue #33 - assuming other people agree that the behavior of `o` and `O` should be changed.