### PR TITLE
Fix 'o' on folded headings

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -52,7 +52,7 @@
 (defun evil-org-eol-call (fun)
   "Go to end of line and call provided function.
 FUN function callback"
-  (end-of-line)
+  (end-of-visible-line)
   (funcall fun)
   (evil-append nil)
   )


### PR DESCRIPTION
This is should fix issue #33. 